### PR TITLE
feat: setup a ping slash command to test the connection 

### DIFF
--- a/.env
+++ b/.env
@@ -1,10 +1,11 @@
 # Curioucity backend
-BACKEND_HOSTNAME=curioucity_server
+BACKEND_HOST=curioucity_server
 BACKEND_PORT=8080
 
 # Discord bot
 GUILD_ID=869461606541705236
-DISCORD_BOT_NAME=curious
+DISCORD_BOT_HOST=curious
 
 # Database
-DATABASE_NAME=curioucity_db
+DATABASE_HOST=curioucity_db
+DATABASE_PORT=5656

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -164,6 +164,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "core-foundation"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "194a7a9e6de53fa55116934067c844d9d749312f75c6f6d0980e8c252f8c2146"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
 name = "core-foundation-sys"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -212,6 +222,7 @@ name = "discord-bot"
 version = "0.1.0"
 dependencies = [
  "chrono",
+ "reqwest",
  "serde_json",
  "serenity",
  "tokio",
@@ -224,6 +235,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9852635589dc9f9ea1b6fe9f05b50ef208c85c834a562f0c6abb1c475736ec2b"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "fastrand"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7a407cfaa3385c4ae6b23e84623d48c2798d06e3e6a1878f7f59f17b3f86499"
+dependencies = [
+ "instant",
 ]
 
 [[package]]
@@ -241,6 +261,21 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "foreign-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+dependencies = [
+ "foreign-types-shared",
+]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "form_urlencoded"
@@ -449,6 +484,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper-tls"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
+dependencies = [
+ "bytes",
+ "hyper",
+ "native-tls",
+ "tokio",
+ "tokio-native-tls",
+]
+
+[[package]]
 name = "iana-time-zone"
 version = "0.1.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -482,6 +530,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "instant"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "ipnet"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -501,6 +558,12 @@ checksum = "49409df3e3bf0856b916e2ceaca09ee28e6871cf7d9ce97a692cacfdb2a25a47"
 dependencies = [
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "lazy_static"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
@@ -577,6 +640,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "native-tls"
+version = "0.2.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd7e2f3618557f980e0b17e8856252eee3c97fa12c54dff0ca290fb6266ca4a9"
+dependencies = [
+ "lazy_static",
+ "libc",
+ "log",
+ "openssl",
+ "openssl-probe",
+ "openssl-sys",
+ "schannel",
+ "security-framework",
+ "security-framework-sys",
+ "tempfile",
+]
+
+[[package]]
 name = "num-integer"
 version = "0.1.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -619,6 +700,51 @@ name = "once_cell"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e82dad04139b71a90c080c8463fe0dc7902db5192d939bd0950f074d014339e1"
+
+[[package]]
+name = "openssl"
+version = "0.10.42"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12fc0523e3bd51a692c8850d075d74dc062ccf251c0110668cbd921917118a13"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "foreign-types",
+ "libc",
+ "once_cell",
+ "openssl-macros",
+ "openssl-sys",
+]
+
+[[package]]
+name = "openssl-macros"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b501e44f11665960c7e7fcf062c7d96a14ade4aa98116c004b2e37b5be7d736c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "openssl-probe"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.76"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5230151e44c0f05157effb743e8d517472843121cf9243e8b81393edb5acd9ce"
+dependencies = [
+ "autocfg",
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
 
 [[package]]
 name = "ordered-float"
@@ -691,6 +817,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
+name = "pkg-config"
+version = "0.3.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1df8c4ec4b0627e53bdf214615ad287367e482558cf84b109250b37464dc03ae"
+
+[[package]]
 name = "ppv-lite86"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -754,6 +886,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "remove_dir_all"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3acd125665422973a33ac9d3dd2df85edad0f4ae9b00dafb1a05e43a9f5ef8e7"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "reqwest"
 version = "0.11.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -769,11 +910,13 @@ dependencies = [
  "http-body",
  "hyper",
  "hyper-rustls",
+ "hyper-tls",
  "ipnet",
  "js-sys",
  "log",
  "mime",
  "mime_guess",
+ "native-tls",
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
@@ -783,6 +926,7 @@ dependencies = [
  "serde_json",
  "serde_urlencoded",
  "tokio",
+ "tokio-native-tls",
  "tokio-rustls",
  "tokio-util",
  "tower-service",
@@ -837,6 +981,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4501abdff3ae82a1c1b477a17252eb69cee9e66eb915c1abaa4f44d873df9f09"
 
 [[package]]
+name = "schannel"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88d6731146462ea25d9244b2ed5fd1d716d25c52e4d54aa4fb0f3c4e9854dbe2"
+dependencies = [
+ "lazy_static",
+ "windows-sys",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -850,6 +1004,29 @@ checksum = "d53dcdb7c9f8158937a7981b48accfd39a43af418591a5d008c7b22b5e1b7ca4"
 dependencies = [
  "ring",
  "untrusted",
+]
+
+[[package]]
+name = "security-framework"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bc1bb97804af6631813c55739f771071e0f2ed33ee20b68c86ec505d906356c"
+dependencies = [
+ "bitflags",
+ "core-foundation",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0160a13a177a45bfb43ce71c01580998474f556ad854dcbca936dd2841a5c556"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
@@ -1012,6 +1189,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "20518fe4a4c9acf048008599e464deb21beeae3d3578418951a189c235a7a9a8"
 
 [[package]]
+name = "tempfile"
+version = "3.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5cdb1ef4eaeeaddc8fbd371e5017057064af0911902ef36b39801f67cc6d79e4"
+dependencies = [
+ "cfg-if",
+ "fastrand",
+ "libc",
+ "redox_syscall",
+ "remove_dir_all",
+ "winapi",
+]
+
+[[package]]
 name = "thiserror"
 version = "1.0.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1098,6 +1289,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "tokio-native-tls"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7d995660bd2b7f8c1568414c1126076c13fbb725c40112dc0120b78eb9b717b"
+dependencies = [
+ "native-tls",
+ "tokio",
 ]
 
 [[package]]
@@ -1297,6 +1498,12 @@ name = "utf-8"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
+
+[[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "version_check"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,31 +2,33 @@ version: '3.9'
 
 services:
   backend:
-    container_name: ${BACKEND_HOSTNAME}
+    container_name: ${BACKEND_HOST}
     ports: 
-      - "${BACKEND_PORT}:8080"
+      - ${BACKEND_PORT}:8080
     build:
       context: ./packages/server
       dockerfile: Dockerfile
     environment:
-      PORT: 8080
-    env_file:
-      - .env
-      - .env.local
+      BACKEND_PORT: ${BACKEND_PORT}
+
   discord:
-    container_name: ${DISCORD_BOT_NAME}
+    container_name: ${DISCORD_BOT_HOST}
     build:
       context: ./packages/discord-bot
       dockerfile: Dockerfile
-    env_file:
-      - .env
-      - .env.local
-  database:
-    container_name: ${DATABASE_NAME}
-    image: edgedb/edgedb
     environment:
-      EDGEDB_SERVER_SECURITY: insecure_dev_mode
-    volumes:
-      - "./dbschema:/dbschema"
-    ports:
-      - "5656:5656"
+      BACKEND_PORT: ${BACKEND_PORT}
+      BACKEND_HOST: ${BACKEND_HOST}
+      GUILD_ID: ${GUILD_ID}
+    env_file:
+      - .env.local
+
+  # database:
+  #   container_name: ${DATABASE_HOST}
+  #   image: edgedb/edgedb
+  #   environment:
+  #     EDGEDB_SERVER_SECURITY: insecure_dev_mode
+  #   volumes:
+  #     - "./dbschema:/dbschema"
+  #   ports:
+  #     - ${DATABASE_PORT}:5656

--- a/packages/discord-bot/Cargo.toml
+++ b/packages/discord-bot/Cargo.toml
@@ -10,4 +10,5 @@ tokio = { version = "1.21.1", features = ["full"] }
 serenity = {version ="0.11", default-features = false, features = ["client", "gateway", "rustls_backend", "model"]}
 serde_json = "1.0"
 chrono = "0.4"
+reqwest = { version = "0.11", features = ["json"] }
 

--- a/packages/discord-bot/Dockerfile
+++ b/packages/discord-bot/Dockerfile
@@ -26,5 +26,10 @@ RUN cargo build --release
 # Serve
 FROM debian:buster-slim
 COPY --from=builder /discord-bot/target/release/discord-bot .
+
+# Reqwest needs libssl in linux
+RUN apt-get update; apt-get upgrade -y
+RUN apt-get install -y libssl-dev pkg-config
+
 USER 1000
 CMD ["./discord-bot"]

--- a/packages/discord-bot/src/commands/curious_ping.rs
+++ b/packages/discord-bot/src/commands/curious_ping.rs
@@ -1,0 +1,35 @@
+use std::env;
+
+use serenity::builder::CreateApplicationCommand;
+use serenity::model::prelude::interaction::application_command::CommandDataOption;
+
+pub fn register(command: &mut CreateApplicationCommand) -> &mut CreateApplicationCommand {
+    command.name("curious-ping").description("Test pong")
+}
+
+pub async fn run(_options: &[CommandDataOption]) -> String {
+    let backend_host = env::var("BACKEND_HOST").expect("Expected backend host in the environment");
+    let backend_port = env::var("BACKEND_PORT").expect("Expected backend port in the environment");
+    let client = reqwest::Client::new();
+
+    let resp = client
+        .get(format!(
+            "http://{host}:{port}",
+            host = backend_host,
+            port = backend_port
+        ))
+        .send()
+        .await;
+
+    match resp {
+        Ok(response) => {
+            println!("Response: {:?}", response.text().await);
+        }
+        Err(error) => {
+            println!("Error: {:?}", error);
+            return "Something went wrong".to_string();
+        }
+    }
+
+    "Hey, I'm alive!".to_string()
+}

--- a/packages/discord-bot/src/commands/mod.rs
+++ b/packages/discord-bot/src/commands/mod.rs
@@ -1,3 +1,4 @@
 pub mod curious_help;
 pub mod curious_list_active_thread;
+pub mod curious_ping;
 pub mod curious_save;

--- a/packages/discord-bot/src/main.rs
+++ b/packages/discord-bot/src/main.rs
@@ -20,6 +20,7 @@ impl EventHandler for Handler {
 
             let content = match command.data.name.as_str() {
                 "curious-help" => commands::curious_help::run(&command.data.options),
+                "curious-ping" => commands::curious_ping::run(&command.data.options).await,
                 "curious-save" => {
                     commands::curious_save::run(&command.data.options, channel_id).await
                 }
@@ -50,20 +51,16 @@ impl EventHandler for Handler {
                 .expect("GUILD_ID must be an integer"),
         );
 
-        let commands = GuildId::set_application_commands(&guild_id, &ctx.http, |commands| {
+        let _commands = GuildId::set_application_commands(&guild_id, &ctx.http, |commands| {
             commands
                 .create_application_command(|command| commands::curious_help::register(command))
+                .create_application_command(|command| commands::curious_ping::register(command))
                 .create_application_command(|command| commands::curious_save::register(command))
                 .create_application_command(|command| {
                     commands::curious_list_active_thread::register(command)
                 })
         })
         .await;
-
-        println!(
-            "I now have the following guild slash commands: {:#?}",
-            commands
-        );
     }
 }
 

--- a/packages/server/src/main.rs
+++ b/packages/server/src/main.rs
@@ -11,9 +11,10 @@ async fn main() {
     let app = Router::new()
         .fallback(fallback.into_service())
         .route("/", axum::routing::get(hello))
+        .route("/ping", axum::routing::get(pong))
         .route("/discord/thread", post(create_discord_thread));
 
-    let port = std::env::var("PORT")
+    let port = std::env::var("BACKEND_PORT")
         .ok()
         .and_then(|s| s.parse().ok())
         .unwrap_or(8010);
@@ -30,6 +31,10 @@ async fn main() {
 
 async fn hello() -> String {
     "Hello, World!".into()
+}
+
+async fn pong() -> String {
+    "Pong".into()
 }
 
 async fn fallback(uri: axum::http::Uri) -> impl axum::response::IntoResponse {


### PR DESCRIPTION
This commit sets up a custom/temp slash command /curious-ping. This command will trigger a request to the API endpoint. We also leverage environment variables to pass host and port around our services.

note: I am still using HTTP in the interior request inside the docker, not sure whether this act is secure or not. We need to dip deeper into it.