### PR TITLE
feat: update db schema

### DIFF
--- a/dbschema/default.esdl
+++ b/dbschema/default.esdl
@@ -4,18 +4,30 @@ module default {
     required property name -> str;
     property icon -> str;
     multi link threads -> DiscordThread;
+    multi link tags -> Tag;
   }
 
   type DiscordThread {
     required property thread_channel_id -> int64;
     property full_messages_json -> json;
-    multi link messages -> DiscordMessage;
+    multi link messages -> DiscordMessage {
+      constraint exclusive;
+      property order -> int64;
+    };
     property create_at -> datetime;
+    property markdown_content -> str;
+    multi link tags -> Tag;
   }
 
   type DiscordMessage {
     required property message_id -> int64;
     property content -> str;
     property create_at -> datetime;
+    property markdown_content -> str;
+    multi link tags -> Tag;
+  }
+
+  type Tag {
+    required property name -> str;
   }
 }

--- a/dbschema/migrations/00002.edgeql
+++ b/dbschema/migrations/00002.edgeql
@@ -1,0 +1,26 @@
+CREATE MIGRATION m1ksinxc4ey4bwkpairwdkd2xktrbruf3azjxf75dpvzq42dxbl5ta
+    ONTO m1frhunu72db6ffbremwp7weyayzpumctjx5u455fsv5mvaxi27iva
+{
+  CREATE TYPE default::Tag {
+      CREATE REQUIRED PROPERTY name -> std::str;
+  };
+  ALTER TYPE default::DiscordGuild {
+      CREATE MULTI LINK tags -> default::Tag;
+  };
+  ALTER TYPE default::DiscordMessage {
+      CREATE MULTI LINK tags -> default::Tag;
+      CREATE PROPERTY markdown_content -> std::str;
+  };
+  ALTER TYPE default::DiscordThread {
+      ALTER LINK messages {
+          CREATE CONSTRAINT std::exclusive;
+          CREATE PROPERTY order -> std::int64;
+      };
+  };
+  ALTER TYPE default::DiscordThread {
+      CREATE MULTI LINK tags -> default::Tag;
+  };
+  ALTER TYPE default::DiscordThread {
+      CREATE PROPERTY markdown_content -> std::str;
+  };
+};


### PR DESCRIPTION
This commit updates edgeDB schema. It adds a type Tag and link between each type. It also makes DiscordThread.messages exclusive of the one-to-many relationship.