### PR TITLE
feat: migrate to proto

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,6 @@ yarn-error.log*
 
 # rust
 target
+
+## protobuf
+**/gen

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -39,6 +39,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "983cd8b9d4b02a6dc6ffa557262eb5858a27a0038ffffe21a0f133eaa819a164"
 
 [[package]]
+name = "async-stream"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dad5c83079eae9969be7fadefe640a1c566901f05ff91ab221de4b6f68d9507e"
+dependencies = [
+ "async-stream-impl",
+ "futures-core",
+]
+
+[[package]]
+name = "async-stream-impl"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10f203db73a71dfa2fb6dd22763990fa26f3d2625a6da2da900d23b87d26be27"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "async-trait"
 version = "0.1.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -358,6 +379,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "either"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90e5c1c8368803113bf0c9584fc495a58b86dc8a29edbf8fe877d21d9507e797"
+
+[[package]]
 name = "encoding_rs"
 version = "0.8.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -387,6 +414,12 @@ checksum = "a7a407cfaa3385c4ae6b23e84623d48c2798d06e3e6a1878f7f59f17b3f86499"
 dependencies = [
  "instant",
 ]
+
+[[package]]
+name = "fixedbitset"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
 
 [[package]]
 name = "flate2"
@@ -653,6 +686,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper-timeout"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbb958482e8c7be4bc3cf272a766a2b0bf1a6755e7a6ae777f017a31d11b13b1"
+dependencies = [
+ "hyper",
+ "pin-project-lite",
+ "tokio",
+ "tokio-io-timeout",
+]
+
+[[package]]
 name = "hyper-tls"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -712,6 +757,15 @@ name = "ipnet"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "879d54834c8c76457ef4293a689b2a8c59b076067ad77b15efafbb05f92a592b"
+
+[[package]]
+name = "itertools"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
+]
 
 [[package]]
 name = "itoa"
@@ -807,6 +861,12 @@ dependencies = [
  "wasi 0.11.0+wasi-snapshot-preview1",
  "windows-sys",
 ]
+
+[[package]]
+name = "multimap"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5ce46fe64a9d73be07dcbe690a38ce1b293be448fd8ce1e6c1b8062c9f72c6a"
 
 [[package]]
 name = "native-tls"
@@ -948,6 +1008,43 @@ dependencies = [
 ]
 
 [[package]]
+name = "pbjson"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "599fe9aefc2ca0df4a96179b3075faee2cacb89d4cf947a00b9a89152dfffc9d"
+dependencies = [
+ "base64",
+ "serde",
+]
+
+[[package]]
+name = "pbjson-build"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b237671f44cffe48853b93cba79d2613a62c8250b902a93f11f4be4539c84287"
+dependencies = [
+ "heck",
+ "itertools",
+ "prost",
+ "prost-types",
+]
+
+[[package]]
+name = "pbjson-types"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "588ae4a372e9fa9c20524dacd39e666b6abd29ff2830b9ebec5437e41634067d"
+dependencies = [
+ "bytes",
+ "chrono",
+ "pbjson",
+ "pbjson-build",
+ "prost",
+ "prost-build",
+ "serde",
+]
+
+[[package]]
 name = "pem"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -963,6 +1060,16 @@ name = "percent-encoding"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "478c572c3d73181ff3c2539045f6eb99e5491218eae919370993b890cdbdd98e"
+
+[[package]]
+name = "petgraph"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6d5014253a1331579ce62aa67443b4a658c5e7dd03d4bc6d302b94474888143"
+dependencies = [
+ "fixedbitset",
+ "indexmap",
+]
 
 [[package]]
 name = "pin-project"
@@ -1015,6 +1122,59 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94e2ef8dbfc347b10c094890f778ee2e36ca9bb4262e86dc99cd217e35f3470b"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "prost"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "399c3c31cdec40583bb68f0b18403400d01ec4289c383aa047560439952c4dd7"
+dependencies = [
+ "bytes",
+ "prost-derive",
+]
+
+[[package]]
+name = "prost-build"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f835c582e6bd972ba8347313300219fed5bfa52caf175298d860b61ff6069bb"
+dependencies = [
+ "bytes",
+ "heck",
+ "itertools",
+ "lazy_static",
+ "log",
+ "multimap",
+ "petgraph",
+ "prost",
+ "prost-types",
+ "regex",
+ "tempfile",
+ "which",
+]
+
+[[package]]
+name = "prost-derive"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7345d5f0e08c0536d7ac7229952590239e77abf0a0100a1b1d890add6ea96364"
+dependencies = [
+ "anyhow",
+ "itertools",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "prost-types"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4dfaa718ad76a44b3415e6c4d53b17c8f99160dcb3a99b10470fce8ad43f6e3e"
+dependencies = [
+ "bytes",
+ "prost",
 ]
 
 [[package]]
@@ -1402,9 +1562,13 @@ dependencies = [
  "edgedb-derive",
  "edgedb-protocol",
  "edgedb-tokio",
+ "pbjson",
+ "pbjson-types",
+ "prost",
  "serde",
  "serde_json",
  "tokio",
+ "tonic",
  "uuid",
 ]
 
@@ -1693,6 +1857,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-io-timeout"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30b74022ada614a1b4834de765f9bb43877f910cc8ce4be40e89042c9223a8bf"
+dependencies = [
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
 name = "tokio-macros"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1725,6 +1899,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-stream"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d660770404473ccd7bc9f8b28494a811bc18542b915c0855c51e8f419d5223ce"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
 name = "tokio-util"
 version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1748,6 +1933,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "tonic"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55b9af819e54b8f33d453655bef9b9acc171568fb49523078d0cc4e7484200ec"
+dependencies = [
+ "async-stream",
+ "async-trait",
+ "axum",
+ "base64",
+ "bytes",
+ "flate2",
+ "futures-core",
+ "futures-util",
+ "h2",
+ "http",
+ "http-body",
+ "hyper",
+ "hyper-timeout",
+ "percent-encoding",
+ "pin-project",
+ "prost",
+ "prost-derive",
+ "tokio",
+ "tokio-stream",
+ "tokio-util",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+ "tracing-futures",
+]
+
+[[package]]
 name = "tower"
 version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1755,9 +1973,13 @@ checksum = "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c"
 dependencies = [
  "futures-core",
  "futures-util",
+ "indexmap",
  "pin-project",
  "pin-project-lite",
+ "rand 0.8.5",
+ "slab",
  "tokio",
+ "tokio-util",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -1825,6 +2047,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5aeea4303076558a00714b823f9ad67d58a3bbda1df83d8827d21193156e22f7"
 dependencies = [
  "once_cell",
+]
+
+[[package]]
+name = "tracing-futures"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97d095ae15e245a057c8e8451bab9b3ee1e1f68e9ba2b4fbc18d0ac5237835f2"
+dependencies = [
+ "pin-project",
+ "tracing",
 ]
 
 [[package]]
@@ -2108,6 +2340,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "368bfe657969fb01238bb756d351dcade285e0f6fcbd36dcb23359a5169975be"
 dependencies = [
  "webpki",
+]
+
+[[package]]
+name = "which"
+version = "4.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c831fbbee9e129a8cf93e7747a82da9d95ba8e16621cae60ec2cdc849bacb7b"
+dependencies = [
+ "either",
+ "libc",
+ "once_cell",
 ]
 
 [[package]]

--- a/packages/server/.build.rs
+++ b/packages/server/.build.rs
@@ -1,0 +1,16 @@
+use std::error::Error;
+use std::process::{exit, Command};
+
+fn main() -> Result<(), Box<dyn Error>> {
+    let status = Command::new("buf")
+        .arg("generate")
+        .current_dir(env!("CARGO_MANIFEST_DIR"))
+        .status()
+        .unwrap();
+
+    if !status.success() {
+        exit(status.code().unwrap_or(-1))
+    }
+
+    Ok(())
+}

--- a/packages/server/Cargo.toml
+++ b/packages/server/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 
 [dependencies]
 axum = "0.5.16"
-serde = { version = "1.0", features = ["derive"] }
+serde = "1.0"
 tokio = { version = "1", features = ["full"] }
 serde_json = "1.0"
 anyhow = "1.0"
@@ -15,3 +15,7 @@ edgedb-tokio = { git = "https://github.com/edgedb/edgedb-rust", branch = "master
 edgedb-derive = { git = "https://github.com/edgedb/edgedb-rust", branch = "master" }
 edgedb-protocol = { git = "https://github.com/edgedb/edgedb-rust", branch = "master" }
 uuid = { version = "1.2.1", features = ["v4", "serde"] }
+tonic = { version = "0.8", features = ["gzip"] }
+prost = "0.11.0"
+pbjson = "0.4"
+pbjson-types = "0.4"

--- a/packages/server/buf.gen.yaml
+++ b/packages/server/buf.gen.yaml
@@ -1,0 +1,15 @@
+version: v1
+plugins:
+  - remote: buf.build/prost/plugins/prost:v0.2.0-2
+    out: src/gen
+    opt:
+      - compile_well_known_types
+      - extern_path=.google.protobuf=::pbjson_types
+      - file_descriptor_set
+  - remote: buf.build/prost/plugins/serde:v0.2.0-2
+    out: src/gen
+  - remote: buf.build/prost/plugins/tonic:v0.2.0-2
+    out: src/gen
+    opt:
+      - compile_well_known_types
+      - extern_path=.google.protobuf=::pbjson_types

--- a/packages/server/buf.work.yaml
+++ b/packages/server/buf.work.yaml
@@ -1,0 +1,3 @@
+version: v1
+directories:
+  - proto

--- a/packages/server/proto/buf.yaml
+++ b/packages/server/proto/buf.yaml
@@ -1,0 +1,1 @@
+version: v1

--- a/packages/server/proto/curioucity/v1alpha/general.proto
+++ b/packages/server/proto/curioucity/v1alpha/general.proto
@@ -1,0 +1,10 @@
+syntax = "proto3";
+package curioucity.v1alpha;
+
+enum ResourceType {
+  RESOURCE_TYPE_UNSPECIFIED = 0;
+  RESOURCE_TYPE_WEBSITE = 1;
+  RESOURCE_TYPE_DISCORDGUILD = 2;
+  RESOURCE_TYPE_DISCORDTHREAD = 3;
+  RESOURCE_TYPE_DISCORDMESSAGE = 4;
+}

--- a/packages/server/proto/curioucity/v1alpha/tag.proto
+++ b/packages/server/proto/curioucity/v1alpha/tag.proto
@@ -1,0 +1,6 @@
+syntax = "proto3";
+package curioucity.v1alpha;
+
+message Tag {
+  string name = 1;
+}

--- a/packages/server/proto/curioucity/v1alpha/url.proto
+++ b/packages/server/proto/curioucity/v1alpha/url.proto
@@ -1,0 +1,11 @@
+syntax = "proto3";
+package curioucity.v1alpha;
+
+import "curioucity/v1alpha/general.proto";
+
+message Url {
+  string id = 1;
+  string url = 2;
+  repeated Url references = 3;
+  curioucity.v1alpha.ResourceType resource_type = 4;
+}

--- a/packages/server/proto/third_party/v1alpha/discord.proto
+++ b/packages/server/proto/third_party/v1alpha/discord.proto
@@ -1,0 +1,33 @@
+syntax = "proto3";
+package third_party.v1alpha;
+
+import "curioucity/v1alpha/tag.proto";
+import "curioucity/v1alpha/url.proto";
+
+message DiscordGuild {
+  int64 guild_id = 1;
+  string name = 2;
+  string icon = 3;
+  repeated DiscordThread threads = 4;
+  repeated curioucity.v1alpha.Tag tags = 5;
+  curioucity.v1alpha.Url url = 6;
+}
+
+message DiscordThread {
+  int64 thread_id = 1;
+  map<string, string> full_messages_json = 2;
+  string markdown_content = 3;
+  repeated curioucity.v1alpha.Tag tags = 4;
+  repeated DiscordMessage messages = 5;
+  curioucity.v1alpha.Url url = 6;
+  string create_at = 7;
+}
+
+message DiscordMessage {
+  int64 message_id = 1;
+  string content = 2;
+  string markdown_content = 3;
+  repeated curioucity.v1alpha.Tag tags = 4;
+  curioucity.v1alpha.Url url = 5;
+  string create_at = 6;
+}

--- a/packages/server/proto/third_party/v1alpha/website.proto
+++ b/packages/server/proto/third_party/v1alpha/website.proto
@@ -1,0 +1,7 @@
+syntax = "proto3";
+package third_party.v1alpha;
+
+message Website {
+  string id = 1;
+  string content = 2;
+}

--- a/packages/server/src/db/model/curioucity/url.rs
+++ b/packages/server/src/db/model/curioucity/url.rs
@@ -4,7 +4,7 @@ use edgedb_protocol::model::Uuid;
 use edgedb_tokio::Client;
 use serde::{Deserialize, Serialize};
 
-use crate::db::model::curioucity::general::{ResourceType, ResourceUnion};
+use crate::db::model::curioucity::general::ResourceType;
 
 #[derive(Queryable, Serialize, Deserialize, Debug)]
 pub struct Url {
@@ -12,7 +12,6 @@ pub struct Url {
     pub url: String,
     pub references: Vec<Url>,
     pub resource_type: ResourceType,
-    pub resource: Option<ResourceUnion>,
 }
 
 #[derive(Deserialize, Serialize)]

--- a/packages/server/src/db/model/third_party/discord.rs
+++ b/packages/server/src/db/model/third_party/discord.rs
@@ -2,7 +2,7 @@ use edgedb_derive::Queryable;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
-use crate::db::model::curioucity::Tag;
+use crate::db::model::curioucity::{Tag, Url};
 
 #[derive(Queryable, Serialize, Deserialize, Debug)]
 pub struct DiscordGuild {
@@ -11,7 +11,7 @@ pub struct DiscordGuild {
     pub icon: String,
     pub threads: Vec<DiscordThread>,
     pub tags: Vec<Tag>,
-    pub url: String,
+    pub url: Url,
 }
 
 #[derive(Queryable, Serialize, Deserialize, Debug)]
@@ -23,7 +23,7 @@ pub struct DiscordThread {
     pub markdown_content: String,
     pub tags: Vec<Tag>,
     pub messages: Vec<DiscordMessage>,
-    pub url: String,
+    pub url: Url,
 }
 
 #[derive(Queryable, Serialize, Deserialize, Debug)]


### PR DESCRIPTION
This commit leverage [protoc-gen-prost](https://github.com/neoeinstein/protoc-gen-prost) and buf.build to implement protobuf protocol. It can successfully generate protobuf types.