### PR TITLE
feat: update protobuf protocol for order_in_thread

### DIFF
--- a/packages/server/proto/third_party/v1alpha/discord.proto
+++ b/packages/server/proto/third_party/v1alpha/discord.proto
@@ -56,5 +56,5 @@ message DiscordMessage {
   curioucity.v1alpha.Url url = 7;
   string created_timestamp_at_discord = 8;
   string created_timestamp_at_curioucity = 9;
-  int64 order_in_thread = 10;
+  int32 order_in_thread = 10;
 }

--- a/packages/server/proto/third_party/v1alpha/discord_service.proto
+++ b/packages/server/proto/third_party/v1alpha/discord_service.proto
@@ -9,12 +9,12 @@ service DiscordService {
 }
 
 message CreateDiscordMessageRequest {
-  int64 message_id = 1;
+  string message_id = 1;
   string content = 2;
   string markdown_content = 3;
   string url = 4;
   int64 created_timestamp_at_discord = 5;
-  int64 order_in_thread = 6;
+  int32 order_in_thread = 6;
 }
 
 message CreateDiscordMessageResponse {

--- a/packages/server/src/db/model/third_party/discord.rs
+++ b/packages/server/src/db/model/third_party/discord.rs
@@ -130,7 +130,7 @@ pub struct DiscordMessage {
     pub url: Url,
     pub created_timestamp_at_curioucity: String,
     pub created_timestamp_at_discord: String,
-    pub order_in_thread: i64,
+    pub order_in_thread: i32,
 }
 
 #[derive(Debug)]
@@ -140,7 +140,7 @@ pub struct CreateDiscordMessagePayload {
     pub markdown_content: String,
     pub url: String,
     pub created_timestamp_at_discord: Datetime,
-    pub order_in_thread: i64,
+    pub order_in_thread: i32,
 }
 
 impl From<DiscordMessage> for pb_third_party::DiscordMessage {
@@ -176,7 +176,7 @@ impl DiscordMessage {
                 created_timestamp_at_discord := <datetime>$3,
                 created_timestamp_at_curioucity := <datetime>$4,
                 url := (select Url filter .url = <str>$5),
-                order_in_thread := <int64>$6,
+                order_in_thread := <int32>$6,
             }
         ) {
             id,

--- a/tests/api/discord.js
+++ b/tests/api/discord.js
@@ -59,10 +59,10 @@ export const createDiscordMessage = () => {
             typeof r.json().discord_message.created_timestamp_at_curioucity !==
               "undefined" &&
             r.json().discord_message.created_timestamp_at_curioucity !== null,
-        // "createDiscordMessage - POST /discord/messages - response body should have correct order_in_thread":
-        //   (r) =>
-        //     r.json().discord_message.order_in_thread ===
-        //     createDiscordMessagePayload.order_in_thread,
+        "createDiscordMessage - POST /discord/messages - response body should have correct order_in_thread":
+          (r) =>
+            r.json().discord_message.order_in_thread ===
+            createDiscordMessagePayload.order_in_thread,
       }
     );
   });


### PR DESCRIPTION
The discord_message field order_in_thread doesn't need int64 type, we can safely store them in int32 type. In this way, we can response int instead of string due to the float number problem of protobuf (It will convert int64 to string) which will lead to inconsistency of this API

close #19 